### PR TITLE
feat/add network image support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,10 +38,19 @@ class MyHomePage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               Image(
-                width: 500,
-                height: 500,
+                width: 200,
+                height: 200,
                 image: Svg('assets/test.svg'),
                 color: Colors.red,
+              ),
+              SizedBox(height: 50),
+              Image(
+                width: 200,
+                height: 200,
+                image: Svg(
+                  'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ubuntu.svg',
+                  source: SvgSource.network,
+                ),
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,12 +75,26 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.10"
+    version: "0.1.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,9 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
+
+publish_to: none
 
 dependencies:
   flutter_svg_provider:
@@ -35,7 +37,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -1,14 +1,22 @@
 library flutter_svg_provider;
 
-import 'dart:async';
 import 'dart:io';
+import 'dart:async';
 import 'dart:ui' as ui show Image, Picture;
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+/// An [Enum] of the possible image path sources.
+enum SvgSource {
+  file,
+  asset,
+  network,
+}
 
 /// Rasterizes given svg picture for displaying in [Image] widget:
 ///
@@ -27,62 +35,82 @@ class Svg extends ImageProvider<SvgImageKey> {
   /// Useful for [DecorationImage].
   /// If not specified, will use size from [Image].
   /// If [Image] not specifies size too, will use default size 100x100.
-  final Size? size; // nullable
+  final Size? size;
 
   /// Color to tint the SVG
   final Color? color;
 
-  /// Defines if the SVG is loaded from assets or read from a file.
-  final bool isAsset;
+  /// Source of svg image
+  final SvgSource source;
+
+  /// Image scale.
+  final double? scale;
 
   /// Width and height can also be specified from [Image] constrictor.
   /// Default size is 100x100 logical pixels.
   /// Different size can be specified in [Image] parameters
-  const Svg(this.path, {this.size, this.color, this.isAsset: true});
+  const Svg(
+    this.path, {
+    this.size,
+    this.scale,
+    this.color,
+    this.source = SvgSource.file,
+  });
 
   @override
   Future<SvgImageKey> obtainKey(ImageConfiguration configuration) {
+    final Color color = this.color ?? Colors.transparent;
+    final double scale = this.scale ?? configuration.devicePixelRatio ?? 1.0;
     final double logicWidth = size?.width ?? configuration.size?.width ?? 100;
     final double logicHeight = size?.height ?? configuration.size?.width ?? 100;
-    final double scale = configuration.devicePixelRatio ?? 1.0;
-    final Color color = this.color ?? Colors.transparent;
 
     return SynchronousFuture<SvgImageKey>(
       SvgImageKey(
-          assetName: path,
-          pixelWidth: (logicWidth * scale).round(),
-          pixelHeight: (logicHeight * scale).round(),
-          scale: scale,
-          color: color),
+        path: path,
+        scale: scale,
+        color: color,
+        source: source,
+        pixelWidth: (logicWidth * scale).round(),
+        pixelHeight: (logicHeight * scale).round(),
+      ),
     );
   }
 
   @override
   ImageStreamCompleter load(SvgImageKey key, nil) {
-    return OneFrameImageStreamCompleter(
-      _loadAsync(key, isAsset),
-    );
+    return OneFrameImageStreamCompleter(_loadAsync(key));
   }
 
-  static Future<ImageInfo> _loadAsync(SvgImageKey key, bool isAsset) async {
-    String rawSvg = (isAsset)
-        ? await rootBundle.loadString(key.assetName)
-        : await File(key.assetName).readAsString();
+  static Future<String> _getSvgString(SvgImageKey key) async {
+    switch (key.source) {
+      case SvgSource.network:
+        return await http.read(Uri.parse(key.path));
+      case SvgSource.asset:
+        return await rootBundle.loadString(key.path);
+      case SvgSource.file:
+        return await File(key.path).readAsString();
+    }
+  }
 
-    final DrawableRoot svgRoot = await svg.fromSvgString(rawSvg, key.assetName);
+  static Future<ImageInfo> _loadAsync(SvgImageKey key) async {
+    final String rawSvg = await _getSvgString(key);
+    final DrawableRoot svgRoot = await svg.fromSvgString(rawSvg, key.path);
     final ui.Picture picture = svgRoot.toPicture(
       size: Size(
         key.pixelWidth.toDouble(),
         key.pixelHeight.toDouble(),
       ),
       clipToViewBox: false,
-      colorFilter:
-          ColorFilter.mode(key.color ?? Colors.transparent, BlendMode.srcATop),
+      colorFilter: ColorFilter.mode(
+        key.color ?? Colors.transparent,
+        BlendMode.srcATop,
+      ),
     );
     final ui.Image image = await picture.toImage(
       key.pixelWidth,
       key.pixelHeight,
     );
+
     return ImageInfo(
       image: image,
       scale: key.scale,
@@ -92,7 +120,6 @@ class Svg extends ImageProvider<SvgImageKey> {
   // Note: == and hashCode not overrided as changes in properties
   // (width, height and scale) are not observable from the here.
   // [SvgImageKey] instances will be compared instead.
-
   @override
   String toString() => '$runtimeType(${describeIdentity(path)})';
 }
@@ -100,15 +127,16 @@ class Svg extends ImageProvider<SvgImageKey> {
 @immutable
 class SvgImageKey {
   const SvgImageKey({
-    required this.assetName,
+    required this.path,
     required this.pixelWidth,
     required this.pixelHeight,
     required this.scale,
+    required this.source,
     this.color,
   });
 
   /// Path to svg asset.
-  final String assetName;
+  final String path;
 
   /// Width in physical pixels.
   /// Used when raterizing.
@@ -121,6 +149,9 @@ class SvgImageKey {
   /// Color to tint the SVG
   final Color? color;
 
+  /// Image source.
+  final SvgSource source;
+
   /// Used to calculate logical size from physical, i.e.
   /// logicalWidth = [pixelWidth] / [scale],
   /// logicalHeight = [pixelHeight] / [scale].
@@ -132,17 +163,19 @@ class SvgImageKey {
     if (other.runtimeType != runtimeType) {
       return false;
     }
+
     return other is SvgImageKey &&
-        other.assetName == assetName &&
+        other.path == path &&
         other.pixelWidth == pixelWidth &&
         other.pixelHeight == pixelHeight &&
-        other.scale == scale;
+        other.scale == scale &&
+        other.source == source;
   }
 
   @override
-  int get hashCode => hashValues(assetName, pixelWidth, pixelHeight, scale);
+  int get hashCode => hashValues(path, pixelWidth, pixelHeight, scale, source);
 
   @override
   String toString() => '${objectRuntimeType(this, 'SvgImageKey')}'
-      '(assetName: "$assetName", pixelWidth: $pixelWidth, pixelHeight: $pixelHeight, scale: $scale)';
+      '(path: "$path", pixelWidth: $pixelWidth, pixelHeight: $pixelHeight, scale: $scale, source: $source)';
 }

--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -54,7 +54,7 @@ class Svg extends ImageProvider<SvgImageKey> {
     this.size,
     this.scale,
     this.color,
-    this.source = SvgSource.file,
+    this.source = SvgSource.asset,
   });
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -178,5 +192,5 @@ packages:
     source: hosted
     version: "5.0.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.24.0-7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,16 @@
 name: flutter_svg_provider
-description: Generate image provider from svg path, use flutter_svg as a dependency.
+description: Generate image provider from svg path, uses flutter_svg and http (for network paths) as a dependency.
 version: 0.1.11
 homepage: https://github.com/yang-f/flutter_svg_provider
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.17.0 <2.0.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0 <2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  http: ^0.13.4
   flutter_svg: ^0.23.0+1
 
 dev_dependencies:


### PR DESCRIPTION
This PR adds support for loading SVG over the network in the image provider using HTTP package.

- chore: remove publishing in example according to lints
- chore: add http dependency
- feat: add network support to the svg image provider
- fix: change the default image source to asset
- docs: add a network image example
