### PR TITLE
refactor: hashValues deprecated on version v3.1.0-0.0.pre.897

### DIFF
--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -203,7 +203,7 @@ class SvgImageKey {
 
   @override
   int get hashCode =>
-      hashValues(path, pixelWidth, pixelHeight, scale, source, svgGetter);
+      Object.hash(path, pixelWidth, pixelHeight, scale, source, svgGetter);
 
   @override
   String toString() => '${objectRuntimeType(this, 'SvgImageKey')}'


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- replacement `hashValues` with `Object.hash()`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
