### PR TITLE
Fix app background svg provider crash

### DIFF
--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -95,7 +95,7 @@ class Svg extends ImageProvider<SvgImageKey> {
 
   static Future<String> _getSvgString(SvgImageKey key) async {
     if (key.svgGetter != null) {
-      final rawSvg = await key.svgGetter!.call(key);
+      final rawSvg = await key.svgGetter!(key);
       if (rawSvg != null) {
         return rawSvg;
       }
@@ -111,20 +111,19 @@ class Svg extends ImageProvider<SvgImageKey> {
   }
 
   static Future<ImageInfo> _loadAsync(SvgImageKey key) async {
-    final String rawSvg = await _getSvgString(key);
+    final rawSvg = await _getSvgString(key);
     final pictureInfo = await vg.loadPicture(
       SvgStringLoader(rawSvg),
       null,
       clipViewbox: false,
     );
-    final ui.Image image = await pictureInfo.picture.toImage(
+    final image = pictureInfo.picture.toImageSync(
       pictureInfo.size.width.round(),
       pictureInfo.size.height.round(),
     );
 
     return ImageInfo(
       image: image,
-      scale: 1.0,
     );
   }
 

--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -117,10 +117,15 @@ class Svg extends ImageProvider<SvgImageKey> {
       null,
       clipViewbox: false,
     );
-    final image = pictureInfo.picture.toImageSync(
-      pictureInfo.size.width.round(),
-      pictureInfo.size.height.round(),
-    );
+    final image = kIsWeb
+        ? await pictureInfo.picture.toImage(
+            pictureInfo.size.width.round(),
+            pictureInfo.size.height.round(),
+          )
+        : pictureInfo.picture.toImageSync(
+            pictureInfo.size.width.round(),
+            pictureInfo.size.height.round(),
+          );
 
     return ImageInfo(
       image: image,


### PR DESCRIPTION
Fixes:
https://github.com/yang-f/flutter_svg_provider/issues/49

Steps to reproduce:
- app using flutter_svg_provider 
- go app to background
- logs show error:
The following _Exception was thrown resolving a single-frame
image stream:
Exception: operation failed
- go app to foreground
- all images using svg_provider are gone

This PR fixes this crash by using direct sync method