### PR TITLE
fix: pass color to flutter_svg

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -110,26 +110,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "41b90ceaec6d79819f31e975e61d479516efe701dea35f891b2f986c1b031422"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.17"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: d47dd206ab14818fe4c90f40f363c4214d33f3f669362c8e63a2c053743acdf9
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.12"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "7e71be3c161472f6c9158ac8875dd8de575060d60b5d159ebca3600ea32c9116"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -197,14 +197,15 @@ class SvgImageKey {
         other.pixelHeight == pixelHeight &&
         other.scale == scale &&
         other.source == source &&
-        other.svgGetter == svgGetter;
+        other.svgGetter == svgGetter &&
+        other.color == color;
   }
 
   @override
   int get hashCode =>
-      Object.hash(path, pixelWidth, pixelHeight, scale, source, svgGetter);
+      Object.hash(path, pixelWidth, pixelHeight, scale, source, svgGetter, color);
 
   @override
   String toString() => '${objectRuntimeType(this, 'SvgImageKey')}'
-      '(path: "$path", pixelWidth: $pixelWidth, pixelHeight: $pixelHeight, scale: $scale, source: $source)';
+      '(path: "$path", pixelWidth: $pixelWidth, pixelHeight: $pixelHeight, color: $color, scale: $scale, source: $source)';
 }

--- a/lib/flutter_svg_provider.dart
+++ b/lib/flutter_svg_provider.dart
@@ -90,7 +90,7 @@ class Svg extends ImageProvider<SvgImageKey> {
   @override
   ImageStreamCompleter loadImage(SvgImageKey key, ImageDecoderCallback decode) {
     return OneFrameImageStreamCompleter(
-      _loadAsync(key),
+      _loadAsync(key, getFilterColor(color)),
     );
   }
 
@@ -113,10 +113,10 @@ class Svg extends ImageProvider<SvgImageKey> {
     }
   }
 
-  static Future<ImageInfo> _loadAsync(SvgImageKey key) async {
+  static Future<ImageInfo> _loadAsync(SvgImageKey key, Color color) async {
     final String rawSvg = await _getSvgString(key);
     final pictureInfo = await vg.loadPicture(
-      SvgStringLoader(rawSvg),
+      SvgStringLoader(rawSvg, theme: SvgTheme(currentColor: color)),
       null,
       clipViewbox: false,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -103,26 +103,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "41b90ceaec6d79819f31e975e61d479516efe701dea35f891b2f986c1b031422"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.17"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: d47dd206ab14818fe4c90f40f363c4214d33f3f669362c8e63a2c053743acdf9
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.12"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "7e71be3c161472f6c9158ac8875dd8de575060d60b5d159ebca3600ea32c9116"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_svg_provider
 description: Generate image provider from svg path, uses flutter_svg and http (for network paths) as a dependency.
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/yang-f/flutter_svg_provider
 
 environment:


### PR DESCRIPTION
It appears that "color" property is not used which leads to an issue with it's never applied = there's no way to change color of SVG icons.

Fixed by passing color (processed by `getFilterColor`) as `currentColor`